### PR TITLE
Handle Sheets API errors

### DIFF
--- a/sheets.py
+++ b/sheets.py
@@ -1,7 +1,9 @@
+import logging
 import os
 
 import gspread
 from google.oauth2.service_account import Credentials
+from gspread.exceptions import APIError
 
 SCOPE = [
     "https://spreadsheets.google.com/feeds",
@@ -16,17 +18,52 @@ history_sheet = None
 groups_sheet = None
 
 
+class SafeWorksheet:
+    """Wrapper for gspread Worksheet that logs API errors."""
+
+    def __init__(self, worksheet):
+        self._worksheet = worksheet
+
+    def __getattr__(self, name):
+        attr = getattr(self._worksheet, name)
+        if not callable(attr):
+            return attr
+
+        def wrapper(*args, **kwargs):
+            try:
+                return attr(*args, **kwargs)
+            except APIError as err:
+                if getattr(err.response, "status", None) in {403, 429}:
+                    logging.warning("Sheets quota/permission error: %s", err)
+                    raise RuntimeError(
+                        "❗ Не вдалося зв’язатися з Google Sheets. Спробуйте пізніше."
+                    ) from err
+                logging.error("Sheets API error: %s", err, exc_info=True)
+                raise
+
+        return wrapper
+
+
 def init_gspread(credentials_file: str) -> None:
     """Initialize Google Sheets connection."""
     global client, sheet, clients_sheet, history_sheet, groups_sheet
     if not os.path.exists(credentials_file):
         raise FileNotFoundError(f"Файл {credentials_file} не знайдено.")
     creds = Credentials.from_service_account_file(credentials_file, scopes=SCOPE)
-    client = gspread.authorize(creds)
-    sheet = client.open(SPREADSHEET_NAME)
-    clients_sheet = sheet.worksheet("Клієнти")
-    history_sheet = sheet.worksheet("История")
-    groups_sheet = sheet.worksheet("Группа")
+    try:
+        client = gspread.authorize(creds)
+        sheet = client.open(SPREADSHEET_NAME)
+        clients_sheet = SafeWorksheet(sheet.worksheet("Клієнти"))
+        history_sheet = SafeWorksheet(sheet.worksheet("История"))
+        groups_sheet = SafeWorksheet(sheet.worksheet("Группа"))
+    except APIError as err:
+        if getattr(err.response, "status", None) in {403, 429}:
+            logging.warning("Sheets quota/permission error: %s", err)
+            raise RuntimeError(
+                "❗ Не вдалося зв’язатися з Google Sheets. Спробуйте пізніше."
+            ) from err
+        logging.error("Sheets API error: %s", err, exc_info=True)
+        raise
 
 
 def get_client_name(row):

--- a/tests/test_sheets_error_handling.py
+++ b/tests/test_sheets_error_handling.py
@@ -1,0 +1,62 @@
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from gspread.exceptions import APIError
+
+import sheets
+
+
+class Resp:
+    def __init__(self, status: int):
+        self.status = status
+        self.reason = ""
+        self.headers = {}
+        self.text = "error"
+
+    def json(self):
+        return {"error": {"message": "test"}}
+
+
+def make_error(status: int) -> APIError:
+    return APIError(Resp(status))
+
+
+@patch("sheets.os.path.exists", return_value=True)
+@patch("sheets.Credentials")
+@patch("sheets.gspread.authorize")
+def test_quota_error(mock_auth, mock_creds, mock_exists, caplog):
+    mock_ws = MagicMock()
+    mock_ws.get_all_records.side_effect = make_error(429)
+    mock_sheet = MagicMock()
+    mock_sheet.worksheet.return_value = mock_ws
+    mock_client = MagicMock(open=MagicMock(return_value=mock_sheet))
+    mock_auth.return_value = mock_client
+    mock_creds.from_service_account_file.return_value = "creds"
+
+    sheets.init_gspread("creds.json")
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError):
+            sheets.clients_sheet.get_all_records()
+    assert any(rec.levelno == logging.WARNING for rec in caplog.records)
+
+
+@patch("sheets.os.path.exists", return_value=True)
+@patch("sheets.Credentials")
+@patch("sheets.gspread.authorize")
+def test_unknown_error(mock_auth, mock_creds, mock_exists, caplog):
+    mock_ws = MagicMock()
+    mock_ws.get_all_records.side_effect = make_error(500)
+    mock_sheet = MagicMock()
+    mock_sheet.worksheet.return_value = mock_ws
+    mock_client = MagicMock(open=MagicMock(return_value=mock_sheet))
+    mock_auth.return_value = mock_client
+    mock_creds.from_service_account_file.return_value = "creds"
+
+    sheets.init_gspread("creds.json")
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(APIError):
+            sheets.clients_sheet.get_all_records()
+    assert any(rec.levelno == logging.ERROR for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `SafeWorksheet` wrapper to log Sheets API errors
- raise `RuntimeError` on quota or permission issues
- log other Sheets errors and re-raise
- add tests mocking gspread to emulate APIError 429/500

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b0eab4188325b8da56fdfe6aa05f