### PR TITLE
Add graceful shutdown

### DIFF
--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,72 @@
+import asyncio
+import logging
+import signal
+from unittest.mock import AsyncMock, MagicMock
+
+import handlers
+import main
+import sheets
+
+
+def test_shutdown(monkeypatch):
+    called = {}
+
+    async def fake_stop():
+        called["stop"] = True
+
+    monkeypatch.setattr(handlers.dp, "stop_polling", fake_stop)
+
+    session = MagicMock()
+    sheets.client = MagicMock(session=session)
+
+    msgs = []
+    monkeypatch.setattr(logging, "info", lambda msg: msgs.append(msg))
+
+    asyncio.run(main.shutdown())
+
+    assert called.get("stop")
+    session.close.assert_called_once()
+    assert "Bot stopped" in msgs
+
+
+def test_main_signal_shutdown(monkeypatch):
+    loop = asyncio.new_event_loop()
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: loop)
+    monkeypatch.setattr(asyncio, "run", lambda coro: loop.run_until_complete(coro))
+
+    handlers_store = {}
+
+    def add_sig(sig, cb):
+        handlers_store[sig] = cb
+
+    loop.add_signal_handler = add_sig
+
+    monkeypatch.setenv("API_TOKEN", "123:abc")
+    monkeypatch.setenv("CREDENTIALS_FILE", "c")
+    monkeypatch.setenv("ADMIN_IDS", "1")
+
+    monkeypatch.setattr(main, "init_gspread", lambda _: None)
+    monkeypatch.setattr(handlers.dp, "start_polling", AsyncMock())
+
+    stopped = {}
+
+    async def fake_stop_polling():
+        stopped["called"] = True
+
+    monkeypatch.setattr(handlers.dp, "stop_polling", fake_stop_polling)
+
+    session = MagicMock()
+    sheets.client = MagicMock(session=session)
+
+    msgs = []
+    monkeypatch.setattr(logging, "info", lambda msg: msgs.append(msg))
+
+    main.main()
+
+    assert signal.SIGINT in handlers_store
+    loop.call_soon(handlers_store[signal.SIGINT])
+    loop.run_until_complete(asyncio.sleep(0))
+
+    assert stopped.get("called")
+    session.close.assert_called_once()
+    assert "Bot stopped" in msgs


### PR DESCRIPTION
## Summary
- stop polling and close gspread session on SIGINT/SIGTERM
- log `Bot stopped`
- add tests for shutdown logic

## Testing
- `pre-commit run --files main.py tests/test_shutdown.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b33b56c48325a5517e10fd789485