### PR TITLE
Add help and ping commands

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import time
 from datetime import datetime, timedelta
 
 from aiogram import Bot, Dispatcher, types
@@ -60,6 +61,26 @@ async def send_welcome(message: types.Message):
         "Вітаю в CRM боті 🐬",
         reply_markup=InlineKeyboardMarkup(inline_keyboard=keyboard),
     )
+
+
+@dp.message(Command(commands=["help"]))
+async def send_help(message: types.Message) -> None:
+    """Send available bot commands."""
+    commands = [
+        "/start - start bot",
+        "/help - list available commands",
+        "/ping - check bot latency",
+    ]
+    await message.answer("\n".join(commands))
+
+
+@dp.message(Command(commands=["ping"]))
+async def ping(message: types.Message) -> None:
+    """Reply with pong and response time."""
+    start = time.monotonic()
+    sent = await message.answer("pong")
+    latency = int((time.monotonic() - start) * 1000)
+    await sent.edit_text(f"pong {latency} ms")
 
 
 @dp.callback_query(lambda c: c.data == "my_sessions")

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,0 +1,36 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import handlers
+
+
+def test_ping_latency(monkeypatch):
+    message = MagicMock()
+    edited = {}
+
+    async def fake_edit(text):
+        edited["text"] = text
+
+    msg = MagicMock(edit_text=AsyncMock(side_effect=fake_edit))
+
+    async def fake_answer(text):
+        assert text == "pong"
+        return msg
+
+    message.answer = AsyncMock(side_effect=fake_answer)
+
+    ts = {"calls": 0}
+
+    def fake_monotonic():
+        ts["calls"] += 1
+        return 1.0 if ts["calls"] == 1 else 1.1
+
+    monkeypatch.setattr(handlers.time, "monotonic", fake_monotonic)
+
+    asyncio.run(handlers.ping(message))
+
+    assert message.answer.await_count == 1
+    assert msg.edit_text.await_count == 1
+    assert edited["text"].startswith("pong ")
+    ms = int(edited["text"].split()[1])
+    assert ms < 1500


### PR DESCRIPTION
## Summary
- add `/help` command listing available commands
- add `/ping` command that returns response latency
- test `/ping` with mocked Telegram API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b5084f5483259e967ea838255d8f