### PR TITLE
Add /stats command with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Simple Telegram bot for CRM integration.
 
+## Commands
+
+- `/ping` - check bot latency
+- `/stats` - show remaining sessions (cached for 30s)
+
 ## Running with Docker
 
 Build the image and run:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,39 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import handlers
+
+
+def test_stats_caching(monkeypatch):
+    message = MagicMock()
+    message.from_user.id = 42
+    result = {}
+
+    async def fake_answer(text):
+        result.setdefault("texts", []).append(text)
+
+    message.answer = AsyncMock(side_effect=fake_answer)
+
+    records = [{"ID": "42", "К-сть тренувань": 3}]
+    sheet = MagicMock(get_all_records=MagicMock(return_value=records))
+    monkeypatch.setattr(handlers, "clients_sheet", sheet)
+
+    now = [0.0]
+    monkeypatch.setattr(handlers.time, "monotonic", lambda: now[0])
+
+    handlers.STATS_CACHE.clear()
+
+    asyncio.run(handlers.stats(message))
+    assert result["texts"][-1] == "У тебя 3 оставшихся"
+    assert sheet.get_all_records.call_count == 1
+
+    now[0] += 10
+    asyncio.run(handlers.stats(message))
+    assert sheet.get_all_records.call_count == 1
+    assert result["texts"][-1] == "У тебя 3 оставшихся"
+
+    now[0] += 31
+    records[0]["К-сть тренувань"] = 4
+    asyncio.run(handlers.stats(message))
+    assert sheet.get_all_records.call_count == 2
+    assert result["texts"][-1] == "У тебя 4 оставшихся"


### PR DESCRIPTION
## Summary
- add a `/stats` command that shows remaining sessions
- cache stats responses for 30 seconds
- list `/stats` in help and README
- test stats caching logic

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q flake8`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b64061b08325bf2991fdb8357b3e