### PR TITLE
creds-fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,8 +56,11 @@ def main() -> None:
 
     if not api_token:
         raise EnvironmentError("API_TOKEN is not set")
-    if not credentials_file:
-        raise EnvironmentError("CREDENTIALS_FILE is not set")
+    if not credentials_file or not os.path.exists(credentials_file):
+        logging.warning(
+            "⚠️  creds.json not found – положи JSON и пропиши CREDENTIALS_FILE"
+        )
+        raise SystemExit(1)
     if not admin_ids:
         raise EnvironmentError("ADMIN_IDS is not set")
 

--- a/tests/test_creds_fallback.py
+++ b/tests/test_creds_fallback.py
@@ -1,12 +1,13 @@
 import sys
 from pathlib import Path
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-import main
+import pytest  # noqa: E402
+
+import main  # noqa: E402
 
 
 def test_missing_credentials(monkeypatch, capsys):
@@ -15,8 +16,10 @@ def test_missing_credentials(monkeypatch, capsys):
     monkeypatch.setenv("ADMIN_IDS", "1")
 
     called = {}
+
     def fake_init(_):
         called["init"] = True
+
     monkeypatch.setattr(main, "init_gspread", fake_init)
 
     with pytest.raises(SystemExit) as exc:
@@ -25,4 +28,3 @@ def test_missing_credentials(monkeypatch, capsys):
     assert not called
     err = capsys.readouterr().err
     assert "creds.json not found" in err
-

--- a/tests/test_creds_fallback.py
+++ b/tests/test_creds_fallback.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import main
+
+
+def test_missing_credentials(monkeypatch, capsys):
+    monkeypatch.delenv("CREDENTIALS_FILE", raising=False)
+    monkeypatch.setenv("API_TOKEN", "1:token")
+    monkeypatch.setenv("ADMIN_IDS", "1")
+
+    called = {}
+    def fake_init(_):
+        called["init"] = True
+    monkeypatch.setattr(main, "init_gspread", fake_init)
+
+    with pytest.raises(SystemExit) as exc:
+        main.main()
+    assert exc.value.code == 1
+    assert not called
+    err = capsys.readouterr().err
+    assert "creds.json not found" in err
+

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -45,6 +45,8 @@ def test_main_signal_shutdown(monkeypatch):
     monkeypatch.setenv("CREDENTIALS_FILE", "c")
     monkeypatch.setenv("ADMIN_IDS", "1")
 
+    monkeypatch.setattr(main.os.path, "exists", lambda path: True)
+
     monkeypatch.setattr(main, "init_gspread", lambda _: None)
     monkeypatch.setattr(handlers.dp, "start_polling", AsyncMock())
 


### PR DESCRIPTION
## Summary
- exit with code 1 when `CREDENTIALS_FILE` is missing or invalid
- patch tests to expect credentials file check
- add regression test for missing credentials

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c1327a508325b740e53ba88fb2c7