### PR TITLE
Fix gspread init with spreadsheet id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 API_TOKEN="7889385855:AAEEEvKm5LPmaWnQlpXVQ4v3X2Qaj-Z6h9c"
 CREDENTIALS_FILE=path/to/credentials.json
+SPREADSHEET_ID=your_spreadsheet_id
 ADMIN_IDS=[597164575]

--- a/tests/test_sheets_error_handling.py
+++ b/tests/test_sheets_error_handling.py
@@ -30,7 +30,7 @@ def test_quota_error(mock_auth, mock_creds, mock_exists, caplog):
     mock_ws.get_all_records.side_effect = make_error(429)
     mock_sheet = MagicMock()
     mock_sheet.worksheet.return_value = mock_ws
-    mock_client = MagicMock(open=MagicMock(return_value=mock_sheet))
+    mock_client = MagicMock(open_by_key=MagicMock(return_value=mock_sheet))
     mock_auth.return_value = mock_client
     mock_creds.from_service_account_file.return_value = "creds"
 
@@ -50,7 +50,7 @@ def test_unknown_error(mock_auth, mock_creds, mock_exists, caplog):
     mock_ws.get_all_records.side_effect = make_error(500)
     mock_sheet = MagicMock()
     mock_sheet.worksheet.return_value = mock_ws
-    mock_client = MagicMock(open=MagicMock(return_value=mock_sheet))
+    mock_client = MagicMock(open_by_key=MagicMock(return_value=mock_sheet))
     mock_auth.return_value = mock_client
     mock_creds.from_service_account_file.return_value = "creds"
 


### PR DESCRIPTION
## Summary
- load `SPREADSHEET_ID` from environment
- open Google Sheets by key
- update tests for new init logic
- document new env variable

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6845f5c4c5f88325bcaaf1f1b3fcdd18