### PR TITLE
Add spreadsheet validation in gspread init

### DIFF
--- a/tests/test_validate_spreadsheet.py
+++ b/tests/test_validate_spreadsheet.py
@@ -1,0 +1,44 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from gspread.exceptions import APIError
+
+import sheets
+
+
+class Resp:
+    def __init__(self, status: int):
+        self.status = status
+        self.reason = ""
+        self.headers = {}
+        self.text = "error"
+
+    def json(self):
+        return {"error": {"message": "test"}}
+
+
+def make_error(status: int) -> APIError:
+    return APIError(Resp(status))
+
+
+def test_validate_ok(caplog):
+    mock_client = MagicMock(open_by_key=MagicMock())
+    sheets.client = mock_client
+    with caplog.at_level(logging.INFO):
+        sheets.validate_spreadsheet("abc")
+    mock_client.open_by_key.assert_called_once_with("abc")
+    assert any("Spreadsheet ID OK" in rec.message for rec in caplog.records)
+
+
+def test_validate_not_found(caplog):
+    mock_client = MagicMock(open_by_key=MagicMock(side_effect=make_error(404)))
+    sheets.client = mock_client
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(APIError):
+            sheets.validate_spreadsheet("abc")
+    assert any("Spreadsheet ID not found" in rec.message for rec in caplog.records)
+    assert any(
+        "https://docs.google.com/spreadsheets/d/abc/edit" in rec.message
+        for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- validate spreadsheet ID before using gspread
- test the new validation helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `pre-commit run --all-files`
- `python main.py` *(fails: HTTPSConnectionPool host='oauth2.googleapis.com' ...)*

------
https://chatgpt.com/codex/tasks/task_e_684948f6c2dc8325bbd71a29407361c6