### PR TITLE
Add safe_worksheet for sheet resolution

### DIFF
--- a/tests/test_safe_worksheet.py
+++ b/tests/test_safe_worksheet.py
@@ -1,0 +1,36 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from gspread.exceptions import WorksheetNotFound
+
+import sheets
+
+
+def test_first_candidate():
+    ws = MagicMock()
+    sheet = MagicMock(worksheet=MagicMock(return_value=ws))
+    result = sheets.safe_worksheet(sheet, "Клиенты", "Клієнти")
+    assert isinstance(result, sheets.SafeWorksheet)
+    sheet.worksheet.assert_called_once_with("Клиенты")
+    assert result._worksheet is ws
+
+
+def test_fallback_candidate():
+    ws = MagicMock()
+    sheet = MagicMock()
+    sheet.worksheet.side_effect = [WorksheetNotFound("no"), ws]
+    result = sheets.safe_worksheet(sheet, "Клиенты", "Клієнти")
+    assert result._worksheet is ws
+    assert sheet.worksheet.call_count == 2
+    sheet.worksheet.assert_any_call("Клиенты")
+    sheet.worksheet.assert_any_call("Клієнти")
+
+
+def test_no_candidate(caplog):
+    sheet = MagicMock()
+    sheet.worksheet.side_effect = WorksheetNotFound("no")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(WorksheetNotFound):
+            sheets.safe_worksheet(sheet, "A", "B")
+    assert any("Worksheet not found" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add `safe_worksheet` helper to pick the first available worksheet name
- use it in `init_gspread`
- test the new helper

## Testing
- `pytest -q`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_684954f9b9308325b879d9a4962be356