### PR TITLE
Fix dotenv loading and simplify start script

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,9 +8,11 @@ from logging.handlers import RotatingFileHandler
 from aiogram import Bot
 from dotenv import load_dotenv
 
-import handlers
-import sheets
-from sheets import init_gspread
+load_dotenv()
+
+import handlers  # noqa: E402
+import sheets  # noqa: E402
+from sheets import init_gspread  # noqa: E402
 
 bot: Bot | None = None
 
@@ -47,7 +49,6 @@ def setup_logging() -> None:
 
 def main() -> None:
     global bot
-    load_dotenv()
 
     setup_logging()
 

--- a/sheets.py
+++ b/sheets.py
@@ -2,8 +2,11 @@ import logging
 import os
 
 import gspread
+from dotenv import load_dotenv
 from google.oauth2.service_account import Credentials
 from gspread.exceptions import APIError, SpreadsheetNotFound, WorksheetNotFound
+
+load_dotenv()
 
 SCOPE = [
     "https://spreadsheets.google.com/feeds",

--- a/start.py
+++ b/start.py
@@ -1,0 +1,4 @@
+from main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- load environment variables earlier
- initialize dotenv in `sheets.py`
- add a lightweight `start.py` helper

## Testing
- `pre-commit run --files main.py sheets.py start.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684961b6d45483258f932fb4ca93a5df