### PR TITLE
Convert gspread to async

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from dotenv import load_dotenv
 load_dotenv()
 
 import handlers  # noqa: E402
-import sheets  # noqa: E402
 from sheets import init_gspread  # noqa: E402
 
 bot: Bot | None = None
@@ -20,8 +19,6 @@ bot: Bot | None = None
 async def shutdown() -> None:
     """Gracefully stop polling and close gspread session."""
     await handlers.dp.stop_polling()
-    if sheets.client is not None:
-        sheets.client.session.close()
     logging.info("Bot stopped")
 
 
@@ -71,11 +68,10 @@ def main() -> None:
     handlers.bot = bot
     handlers.ADMIN_IDS = admin_ids
 
-    init_gspread(credentials_file)
-
     logging.info("Бот запущено")
 
     async def run() -> None:
+        await init_gspread(credentials_file)
         loop = asyncio.get_running_loop()
         if platform.system() != "Windows":
             for sig in (signal.SIGINT, signal.SIGTERM):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aiogram==3.6.0          
-gspread==5.12.0        
-google-auth==2.29.0     
-python-dotenv==1.0.1    
+aiogram==3.6.0
+gspread_asyncio==2.0.0
+google-auth==2.29.0
+python-dotenv==1.0.1
 pytest==8.2.0

--- a/tests/test_creds_fallback.py
+++ b/tests/test_creds_fallback.py
@@ -17,7 +17,7 @@ def test_missing_credentials(monkeypatch, capsys):
 
     called = {}
 
-    def fake_init(_):
+    async def fake_init(_):
         called["init"] = True
 
     monkeypatch.setattr(main, "init_gspread", fake_init)

--- a/tests/test_safe_worksheet.py
+++ b/tests/test_safe_worksheet.py
@@ -1,5 +1,6 @@
+import asyncio
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gspread.exceptions import WorksheetNotFound
@@ -9,8 +10,8 @@ import sheets
 
 def test_first_candidate():
     ws = MagicMock()
-    sheet = MagicMock(worksheet=MagicMock(return_value=ws))
-    result = sheets.safe_worksheet(sheet, "Клиенты", "Клієнти")
+    sheet = MagicMock(worksheet=AsyncMock(return_value=ws))
+    result = asyncio.run(sheets.safe_worksheet(sheet, "Клиенты", "Клієнти"))
     assert isinstance(result, sheets.SafeWorksheet)
     sheet.worksheet.assert_called_once_with("Клиенты")
     assert result._worksheet is ws
@@ -19,8 +20,8 @@ def test_first_candidate():
 def test_fallback_candidate():
     ws = MagicMock()
     sheet = MagicMock()
-    sheet.worksheet.side_effect = [WorksheetNotFound("no"), ws]
-    result = sheets.safe_worksheet(sheet, "Клиенты", "Клієнти")
+    sheet.worksheet = AsyncMock(side_effect=[WorksheetNotFound("no"), ws])
+    result = asyncio.run(sheets.safe_worksheet(sheet, "Клиенты", "Клієнти"))
     assert result._worksheet is ws
     assert sheet.worksheet.call_count == 2
     sheet.worksheet.assert_any_call("Клиенты")
@@ -29,8 +30,8 @@ def test_fallback_candidate():
 
 def test_no_candidate(caplog):
     sheet = MagicMock()
-    sheet.worksheet.side_effect = WorksheetNotFound("no")
+    sheet.worksheet = AsyncMock(side_effect=WorksheetNotFound("no"))
     with caplog.at_level(logging.ERROR):
         with pytest.raises(WorksheetNotFound):
-            sheets.safe_worksheet(sheet, "A", "B")
+            asyncio.run(sheets.safe_worksheet(sheet, "A", "B"))
     assert any("Worksheet not found" in rec.message for rec in caplog.records)

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -16,8 +16,7 @@ def test_shutdown(monkeypatch):
 
     monkeypatch.setattr(handlers.dp, "stop_polling", fake_stop)
 
-    session = MagicMock()
-    sheets.client = MagicMock(session=session)
+    sheets.client = MagicMock()
 
     msgs = []
     monkeypatch.setattr(logging, "info", lambda msg: msgs.append(msg))
@@ -25,7 +24,6 @@ def test_shutdown(monkeypatch):
     asyncio.run(main.shutdown())
 
     assert called.get("stop")
-    session.close.assert_called_once()
     assert "Bot stopped" in msgs
 
 
@@ -47,7 +45,10 @@ def test_main_signal_shutdown(monkeypatch):
 
     monkeypatch.setattr(main.os.path, "exists", lambda path: True)
 
-    monkeypatch.setattr(main, "init_gspread", lambda _: None)
+    async def fake_init(_):
+        return None
+
+    monkeypatch.setattr(main, "init_gspread", fake_init)
     monkeypatch.setattr(handlers.dp, "start_polling", AsyncMock())
 
     stopped = {}
@@ -57,8 +58,7 @@ def test_main_signal_shutdown(monkeypatch):
 
     monkeypatch.setattr(handlers.dp, "stop_polling", fake_stop_polling)
 
-    session = MagicMock()
-    sheets.client = MagicMock(session=session)
+    sheets.client = MagicMock()
 
     msgs = []
     monkeypatch.setattr(logging, "info", lambda msg: msgs.append(msg))
@@ -70,5 +70,4 @@ def test_main_signal_shutdown(monkeypatch):
     loop.run_until_complete(asyncio.sleep(0))
 
     assert stopped.get("called")
-    session.close.assert_called_once()
     assert "Bot stopped" in msgs

--- a/tests/test_validate_spreadsheet.py
+++ b/tests/test_validate_spreadsheet.py
@@ -1,5 +1,6 @@
+import asyncio
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gspread.exceptions import APIError
@@ -23,20 +24,20 @@ def make_error(status: int) -> APIError:
 
 
 def test_validate_ok(caplog):
-    mock_client = MagicMock(open_by_key=MagicMock())
+    mock_client = MagicMock(open_by_key=AsyncMock())
     sheets.client = mock_client
     with caplog.at_level(logging.INFO):
-        sheets.validate_spreadsheet("abc")
-    mock_client.open_by_key.assert_called_once_with("abc")
+        asyncio.run(sheets.validate_spreadsheet("abc"))
+    mock_client.open_by_key.assert_awaited_once_with("abc")
     assert any("Spreadsheet ID OK" in rec.message for rec in caplog.records)
 
 
 def test_validate_not_found(caplog):
-    mock_client = MagicMock(open_by_key=MagicMock(side_effect=make_error(404)))
+    mock_client = MagicMock(open_by_key=AsyncMock(side_effect=make_error(404)))
     sheets.client = mock_client
     with caplog.at_level(logging.ERROR):
         with pytest.raises(APIError):
-            sheets.validate_spreadsheet("abc")
+            asyncio.run(sheets.validate_spreadsheet("abc"))
     assert any("Spreadsheet ID not found" in rec.message for rec in caplog.records)
     assert any(
         "https://docs.google.com/spreadsheets/d/abc/edit" in rec.message


### PR DESCRIPTION
## Summary
- switch Google Sheets API to `gspread_asyncio`
- update handlers to use `Router`
- use async `init_gspread` from main entry point
- adapt tests for async Google Sheets

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c97b50d1883258b289b13ad0a0cd0