### PR TITLE
Refactor env config handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-API_TOKEN="7889385855:AAEEEvKm5LPmaWnQlpXVQ4v3X2Qaj-Z6h9c"
-CREDENTIALS_FILE=path/to/credentials.json
-SPREADSHEET_ID=your_spreadsheet_id
-ADMIN_IDS=[597164575]
+TELEGRAM_BOT_TOKEN=your_bot_token
+GOOGLE_CREDENTIALS_JSON=path/to/credentials.json
+GOOGLE_SHEET_ID=your_spreadsheet_id
+ADMIN_ID=597164575

--- a/handlers.py
+++ b/handlers.py
@@ -13,7 +13,7 @@ from utils.i18n import t
 logger = logging.getLogger(__name__)
 
 bot: Bot | None = None
-ADMIN_IDS: list[int] = []
+ADMIN_ID: str | None = None
 
 STATS_CACHE: dict[str, tuple[float, int]] = {}
 
@@ -21,7 +21,6 @@ RENT_COST_PER_SESSION = 330
 
 dp = Dispatcher()
 router = Router()
-dp.include_router(router)
 
 
 @router.message(lambda message: message.contact)
@@ -49,7 +48,7 @@ async def register_by_contact(message: types.Message):
 
 
 @router.message(Command(commands=["start"]))
-async def send_welcome(message: types.Message):
+async def send_welcome(message: types.Message, admin_id: str):
     keyboard = [
         [InlineKeyboardButton(text="📊 Мої заняття", callback_data="my_sessions")],
         [InlineKeyboardButton(text="📜 Історія занять", callback_data="view_history")],
@@ -65,7 +64,7 @@ async def send_welcome(message: types.Message):
         ],
         [InlineKeyboardButton(text="😼 Таємна кнопка", callback_data="secret_button")],
     ]
-    if message.from_user.id in ADMIN_IDS:
+    if str(message.from_user.id) == admin_id:
         keyboard.insert(
             0,
             [
@@ -171,7 +170,7 @@ async def view_history(callback: CallbackQuery):
 
 
 @router.callback_query(lambda c: c.data == "mark_session")
-async def mark_session(callback: CallbackQuery):
+async def mark_session(callback: CallbackQuery, admin_id: str):
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
             [
@@ -187,7 +186,7 @@ async def mark_session(callback: CallbackQuery):
     )
     logger.info("Отримано запит на списання заняття від %s", callback.from_user.id)
     await bot.send_message(
-        ADMIN_IDS[0],
+        admin_id,
         f"Запит на списання заняття від {callback.from_user.id}",
         reply_markup=keyboard,
     )
@@ -244,7 +243,7 @@ async def approve_deduction(callback: CallbackQuery):
 
 
 @router.callback_query(lambda c: c.data == "request_subscription")
-async def request_subscription(callback: CallbackQuery):
+async def request_subscription(callback: CallbackQuery, admin_id: str):
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
             [
@@ -260,7 +259,7 @@ async def request_subscription(callback: CallbackQuery):
     )
     logger.info("Клієнт %s запитав абонемент", callback.from_user.id)
     await bot.send_message(
-        ADMIN_IDS[0],
+        admin_id,
         f"Запит на новий абонемент від {callback.from_user.id}",
         reply_markup=keyboard,
     )

--- a/main.py
+++ b/main.py
@@ -51,29 +51,35 @@ def main() -> None:
 
     setup_logging()
 
-    api_token = os.getenv("API_TOKEN")
-    credentials_file = os.getenv("CREDENTIALS_FILE")
-    admin_ids = [int(x) for x in os.getenv("ADMIN_IDS", "").split(",") if x.strip()]
+    api_token = os.getenv("TELEGRAM_BOT_TOKEN")
+    credentials_file = os.getenv("GOOGLE_CREDENTIALS_JSON")
+    admin_id = os.getenv("ADMIN_ID")
+    sheet_id = os.getenv("GOOGLE_SHEET_ID")
 
     if not api_token:
-        raise EnvironmentError("API_TOKEN is not set")
+        raise EnvironmentError("TELEGRAM_BOT_TOKEN is not set")
     if not credentials_file or not os.path.exists(credentials_file):
         logger.warning(
-            "⚠️  creds.json not found – положи JSON и пропиши CREDENTIALS_FILE"
+            "⚠️  creds.json not found – положи JSON и пропиши GOOGLE_CREDENTIALS_JSON"
         )
         raise SystemExit(1)
-    if not admin_ids:
-        raise EnvironmentError("ADMIN_IDS is not set")
+    if not admin_id:
+        raise EnvironmentError("ADMIN_ID is not set")
+    if not sheet_id:
+        raise EnvironmentError("GOOGLE_SHEET_ID is not set")
 
     bot = Bot(token=api_token)
 
     handlers.bot = bot
-    handlers.ADMIN_IDS = admin_ids
+    handlers.ADMIN_ID = admin_id
 
     logger.info("Бот запущено")
 
+    handlers.dp["admin_id"] = admin_id
+    handlers.dp.include_router(handlers.router)
+
     async def run() -> None:
-        await init_gspread(credentials_file)
+        await init_gspread(credentials_file, sheet_id)
         loop = asyncio.get_running_loop()
         if platform.system() != "Windows":
             for sig in (signal.SIGINT, signal.SIGTERM):

--- a/sheets.py
+++ b/sheets.py
@@ -20,7 +20,6 @@ SCOPE = [
     "https://spreadsheets.google.com/feeds",
     "https://www.googleapis.com/auth/drive",
 ]
-SPREADSHEET_ID = os.getenv("SPREADSHEET_ID", "spreadsheet_id")
 
 agcm: AsyncioGspreadClientManager | None = None
 client: AsyncioGspreadSpreadsheet | None = None
@@ -90,7 +89,7 @@ async def validate_spreadsheet(spreadsheet_id: str) -> None:
     logger.info("✅ Spreadsheet ID OK")
 
 
-async def init_gspread(credentials_file: str) -> None:
+async def init_gspread(credentials_file: str, sheet_id: str) -> None:
     """Initialize Google Sheets connection."""
     global agcm, client, sheet, clients_sheet, history_sheet, groups_sheet
 
@@ -101,8 +100,8 @@ async def init_gspread(credentials_file: str) -> None:
     agcm = AsyncioGspreadClientManager(lambda: creds)
     try:
         client = await agcm.authorize()
-        await validate_spreadsheet(SPREADSHEET_ID)
-        sheet = await client.open_by_key(SPREADSHEET_ID)
+        await validate_spreadsheet(sheet_id)
+        sheet = await client.open_by_key(sheet_id)
         clients_sheet = await safe_worksheet(sheet, "Клиенты", "Клієнти")
         history_sheet = await safe_worksheet(sheet, "История")
         groups_sheet = await safe_worksheet(sheet, "Группа")

--- a/tests/test_creds_fallback.py
+++ b/tests/test_creds_fallback.py
@@ -11,13 +11,14 @@ import main  # noqa: E402
 
 
 def test_missing_credentials(monkeypatch, capsys):
-    monkeypatch.delenv("CREDENTIALS_FILE", raising=False)
-    monkeypatch.setenv("API_TOKEN", "1:token")
-    monkeypatch.setenv("ADMIN_IDS", "1")
+    monkeypatch.delenv("GOOGLE_CREDENTIALS_JSON", raising=False)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "1:token")
+    monkeypatch.setenv("ADMIN_ID", "1")
+    monkeypatch.setenv("GOOGLE_SHEET_ID", "sheet")
 
     called = {}
 
-    async def fake_init(_):
+    async def fake_init(*_):
         called["init"] = True
 
     monkeypatch.setattr(main, "init_gspread", fake_init)

--- a/tests/test_sheets_error_handling.py
+++ b/tests/test_sheets_error_handling.py
@@ -35,7 +35,7 @@ def test_quota_error(mock_mgr, mock_creds, mock_exists, caplog):
     mock_mgr.return_value.authorize = AsyncMock(return_value=mock_client)
     mock_creds.from_service_account_file.return_value = "creds"
 
-    asyncio.run(sheets.init_gspread("creds.json"))
+    asyncio.run(sheets.init_gspread("creds.json", "sheet"))
 
     with caplog.at_level(logging.WARNING):
         result = asyncio.run(sheets.clients_sheet.get_all_records())
@@ -56,7 +56,7 @@ def test_unknown_error(mock_mgr, mock_creds, mock_exists, caplog):
     mock_mgr.return_value.authorize = AsyncMock(return_value=mock_client)
     mock_creds.from_service_account_file.return_value = "creds"
 
-    asyncio.run(sheets.init_gspread("creds.json"))
+    asyncio.run(sheets.init_gspread("creds.json", "sheet"))
 
     with caplog.at_level(logging.ERROR):
         result = asyncio.run(sheets.clients_sheet.get_all_records())

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -39,13 +39,14 @@ def test_main_signal_shutdown(monkeypatch):
 
     loop.add_signal_handler = add_sig
 
-    monkeypatch.setenv("API_TOKEN", "123:abc")
-    monkeypatch.setenv("CREDENTIALS_FILE", "c")
-    monkeypatch.setenv("ADMIN_IDS", "1")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "123:abc")
+    monkeypatch.setenv("GOOGLE_CREDENTIALS_JSON", "c")
+    monkeypatch.setenv("ADMIN_ID", "1")
+    monkeypatch.setenv("GOOGLE_SHEET_ID", "sheet")
 
     monkeypatch.setattr(main.os.path, "exists", lambda path: True)
 
-    async def fake_init(_):
+    async def fake_init(*_):
         return None
 
     monkeypatch.setattr(main, "init_gspread", fake_init)


### PR DESCRIPTION
## Summary
- configure admin and sheet IDs via environment
- expose admin ID through router context
- load Google Sheets by passed sheet ID
- update examples and tests for new variables

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_684ca808bbd48325854b947c9aa984c1