### PR TITLE
Fix Google auth via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 TELEGRAM_BOT_TOKEN=your_bot_token
-GOOGLE_CREDENTIALS_JSON=path/to/credentials.json
+# Paste service account JSON here as a single line
+GOOGLE_CREDENTIALS_JSON='{"type": "service_account", "project_id": "your_project"}'
 GOOGLE_SHEET_ID=your_spreadsheet_id
 ADMIN_ID=597164575

--- a/main.py
+++ b/main.py
@@ -52,17 +52,11 @@ def main() -> None:
     setup_logging()
 
     api_token = os.getenv("TELEGRAM_BOT_TOKEN")
-    credentials_file = os.getenv("GOOGLE_CREDENTIALS_JSON")
     admin_id = os.getenv("ADMIN_ID")
     sheet_id = os.getenv("GOOGLE_SHEET_ID")
 
     if not api_token:
         raise EnvironmentError("TELEGRAM_BOT_TOKEN is not set")
-    if not credentials_file or not os.path.exists(credentials_file):
-        logger.warning(
-            "⚠️  creds.json not found – положи JSON и пропиши GOOGLE_CREDENTIALS_JSON"
-        )
-        raise SystemExit(1)
     if not admin_id:
         raise EnvironmentError("ADMIN_ID is not set")
     if not sheet_id:
@@ -79,7 +73,7 @@ def main() -> None:
     handlers.dp.include_router(handlers.router)
 
     async def run() -> None:
-        await init_gspread(credentials_file, sheet_id)
+        await init_gspread(sheet_id)
         loop = asyncio.get_running_loop()
         if platform.system() != "Windows":
             for sig in (signal.SIGINT, signal.SIGTERM):

--- a/tests/test_creds_fallback.py
+++ b/tests/test_creds_fallback.py
@@ -16,16 +16,6 @@ def test_missing_credentials(monkeypatch, capsys):
     monkeypatch.setenv("ADMIN_ID", "1")
     monkeypatch.setenv("GOOGLE_SHEET_ID", "sheet")
 
-    called = {}
-
-    async def fake_init(*_):
-        called["init"] = True
-
-    monkeypatch.setattr(main, "init_gspread", fake_init)
-
-    with pytest.raises(SystemExit) as exc:
+    with pytest.raises(ValueError) as exc:
         main.main()
-    assert exc.value.code == 1
-    assert not called
-    err = capsys.readouterr().err
-    assert "creds.json not found" in err
+    assert "GOOGLE_CREDENTIALS_JSON" in str(exc.value)

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -44,7 +44,8 @@ def test_main_signal_shutdown(monkeypatch):
     monkeypatch.setenv("ADMIN_ID", "1")
     monkeypatch.setenv("GOOGLE_SHEET_ID", "sheet")
 
-    monkeypatch.setattr(main.os.path, "exists", lambda path: True)
+    handlers.dp = handlers.Dispatcher()
+    handlers.router = handlers.Router()
 
     async def fake_init(*_):
         return None


### PR DESCRIPTION
## Summary
- switch Google auth to env JSON helper
- update example env file and adapt sheets initialization
- adjust tests for new credentials logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cac0c942883259cb8dde8a1f7ae21